### PR TITLE
Add iframe-based avatar preview using CharacterStudio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/App.tsx
+++ b/App.tsx
@@ -5,7 +5,7 @@ import Header from './components/Header';
 import ExperienceDetail from './components/ExperienceDetail';
 import DiscoverPage from './pages/DiscoverPage';
 import HomePage from './pages/HomePage';
-import AvatarPage from './pages/AvatarPage';
+import AvatarPreviewPage from './pages/AvatarPreviewPage';
 import type { Experience } from './types';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import AuthPage from './pages/AuthPage';
@@ -51,7 +51,7 @@ const AppContent: React.FC = () => {
       case 'Discover':
         return <DiscoverPage onExperienceClick={handleExperienceSelect} />;
       case 'Avatar':
-        return <AvatarPage onNavClick={handleNavClick} />;
+        return <AvatarPreviewPage />;
       case 'Auth':
         return <AuthPage />;
       case 'Profile':

--- a/components/CharacterStudioIframe.tsx
+++ b/components/CharacterStudioIframe.tsx
@@ -1,0 +1,32 @@
+import React, { useRef, useEffect } from 'react';
+import ReactDOM from 'react-dom/client';
+import CharacterStudio from './CharacterStudio';
+
+const CharacterStudioIframe: React.FC = () => {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+
+    const doc = iframe.contentDocument;
+    if (!doc) return;
+
+    doc.open();
+    doc.write('<!DOCTYPE html><html><head><base target="_parent"></head><body style="margin:0;overflow:hidden"></body></html>');
+    doc.close();
+
+    const mountNode = doc.createElement('div');
+    doc.body.appendChild(mountNode);
+    const root = ReactDOM.createRoot(mountNode);
+    root.render(<CharacterStudio />);
+
+    return () => {
+      root.unmount();
+    };
+  }, []);
+
+  return <iframe ref={iframeRef} className="w-full h-full border-0 rounded-lg" />;
+};
+
+export default CharacterStudioIframe;

--- a/pages/AvatarPreviewPage.tsx
+++ b/pages/AvatarPreviewPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import CharacterStudioIframe from '../components/CharacterStudioIframe';
+
+const AvatarPreviewPage: React.FC = () => {
+  return (
+    <div className="w-full h-[80vh]">
+      <CharacterStudioIframe />
+    </div>
+  );
+};
+
+export default AvatarPreviewPage;


### PR DESCRIPTION
## Summary
- embed CharacterStudio inside an iframe component
- expose new Avatar preview page
- ignore build artifacts and dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b68923f09483289152f4a41874692c